### PR TITLE
Support MetaModels 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
     "netzmacht/contao-toolkit": "~3.0",
     "netzmacht/php-javascript-builder": "^1.0.2",
     "netzmacht/php-leaflet": "^1.0",
-    "symfony/config": "^3.4 || ^4.0 || ^5.4",
-    "symfony/dependency-injection": "^3.4.26 || ^4.1.12 || ^5.4",
-    "symfony/event-dispatcher": "^3.4 || ^4.0 || ^5.4",
-    "symfony/http-kernel": "^3.4 || ^4.0 || ^5.4",
-    "symfony/routing": "^3.4 || ^4.0 || ^5.4",
-    "symfony/translation": "^3.4 || ^4.0 || ^5.4"
+    "symfony/config": "^5.4",
+    "symfony/dependency-injection": "^5.4",
+    "symfony/event-dispatcher": "^5.4",
+    "symfony/http-kernel": "^5.4",
+    "symfony/routing": "^5.4",
+    "symfony/translation": "^5.4"
   },
   "conflict": {
     "contao/manager-plugin": "<2.1 || >= 3.0"

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
     "netzmacht/contao-toolkit": "~3.0",
     "netzmacht/php-javascript-builder": "^1.0.2",
     "netzmacht/php-leaflet": "^1.0",
-    "symfony/config": "^5.4",
-    "symfony/dependency-injection": "^5.4",
-    "symfony/event-dispatcher": "^5.4",
-    "symfony/http-kernel": "^5.4",
-    "symfony/routing": "^5.4",
-    "symfony/translation": "^5.4"
+    "symfony/config": "^4.4 || ^5.4",
+    "symfony/dependency-injection": "^4.4 || ^5.4",
+    "symfony/event-dispatcher": "^4.4 || ^5.4",
+    "symfony/http-kernel": "^4.4 || ^5.4",
+    "symfony/routing": "^4.4 || ^5.4",
+    "symfony/translation": "^4.4 || ^5.4"
   },
   "conflict": {
     "contao/manager-plugin": "<2.1 || >= 3.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "contao-community-alliance/dc-general": "~2.1",
     "contao-community-alliance/meta-palettes": "^1.11 || ^2.0",
     "contao/core-bundle": "^4.4",
-    "doctrine/dbal": "^2.6",
+    "doctrine/dbal": "^2.6 || ^3.3",
     "menatwork/contao-multicolumnwizard-bundle": "^3.4.0",
     "metamodels/attribute_select": "~2.1",
     "metamodels/core": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "contao-community-alliance/dc-general": "~2.1",
     "contao-community-alliance/meta-palettes": "^1.11 || ^2.0",
     "contao/core-bundle": "^4.4",
-    "doctrine/dbal": "^2.6 || ^3.3",
+    "doctrine/dbal": "^2.11 || ^3.3",
     "menatwork/contao-multicolumnwizard-bundle": "^3.4.0",
     "metamodels/attribute_select": "~2.1",
     "metamodels/core": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
     "netzmacht/contao-toolkit": "~3.0",
     "netzmacht/php-javascript-builder": "^1.0.2",
     "netzmacht/php-leaflet": "^1.0",
-    "symfony/config": "^3.4 || ^4.0",
-    "symfony/dependency-injection": "^3.4.26 || ^4.1.12",
-    "symfony/event-dispatcher": "^3.4 || ^4.0",
-    "symfony/http-kernel": "^3.4 || ^4.0",
-    "symfony/routing": "^3.4 || ^4.0",
-    "symfony/translation": "^3.4 || ^4.0"
+    "symfony/config": "^3.4 || ^4.0 || ^5.4",
+    "symfony/dependency-injection": "^3.4.26 || ^4.1.12 || ^5.4",
+    "symfony/event-dispatcher": "^3.4 || ^4.0 || ^5.4",
+    "symfony/http-kernel": "^3.4 || ^4.0 || ^5.4",
+    "symfony/routing": "^3.4 || ^4.0 || ^5.4",
+    "symfony/translation": "^3.4 || ^4.0 || ^5.4"
   },
   "conflict": {
     "contao/manager-plugin": "<2.1 || >= 3.0"

--- a/src/EventListener/Dca/LayerDcaListener.php
+++ b/src/EventListener/Dca/LayerDcaListener.php
@@ -96,7 +96,7 @@ final class LayerDcaListener extends AbstractListener
     {
         $result = $this->connection
             ->executeQuery('SELECT id, name FROM tl_metamodel ORDER BY name')
-            ->fetchAll(\PDO::FETCH_ASSOC);
+            ->fetchAllAssociative();
 
         return OptionsBuilder::fromArrayList($result, 'name')->getOptions();
     }

--- a/src/EventListener/Dca/RendererDcaListener.php
+++ b/src/EventListener/Dca/RendererDcaListener.php
@@ -125,7 +125,7 @@ final class RendererDcaListener extends AbstractListener
 
         if ($dataContainer->activeRecord) {
             $repository = $this->repositoryManager->getRepository(LayerModel::class);
-            $layer      = $repository->find((int)$dataContainer->activeRecord->pid);
+            $layer      = $repository->find((int) $dataContainer->activeRecord->pid);
 
             if ($layer === null) {
                 return $settings;
@@ -137,9 +137,9 @@ final class RendererDcaListener extends AbstractListener
                 ->prepare('SELECT id, name FROM tl_metamodel_rendersettings WHERE pid=:metaModelId');
 
             $statement->bindValue('metaModelId', $layer->metamodel);
-            $resutl = $statement->executeQuery();
+            $result = $statement->executeQuery();
 
-            return OptionsBuilder::fromArrayList($resutl->fetchAllAssociative(), 'name')->getOptions();
+            return OptionsBuilder::fromArrayList($result->fetchAllAssociative(), 'name')->getOptions();
         }
 
         return $settings;

--- a/src/EventListener/Dca/RendererDcaListener.php
+++ b/src/EventListener/Dca/RendererDcaListener.php
@@ -125,20 +125,21 @@ final class RendererDcaListener extends AbstractListener
 
         if ($dataContainer->activeRecord) {
             $repository = $this->repositoryManager->getRepository(LayerModel::class);
-            $layer      = $repository->find((int) $dataContainer->activeRecord->pid);
+            $layer      = $repository->find((int)$dataContainer->activeRecord->pid);
 
             if ($layer === null) {
                 return $settings;
             }
 
+            /** @var \Doctrine\DBAL\Statement $statement */
             $statement = $this->repositoryManager
                 ->getConnection()
                 ->prepare('SELECT id, name FROM tl_metamodel_rendersettings WHERE pid=:metaModelId');
 
             $statement->bindValue('metaModelId', $layer->metamodel);
-            $statement->execute();
+            $resutl = $statement->executeQuery();
 
-            return OptionsBuilder::fromArrayList($statement->fetchAll(PDO::FETCH_ASSOC), 'name')->getOptions();
+            return OptionsBuilder::fromArrayList($resutl->fetchAllAssociative(), 'name')->getOptions();
         }
 
         return $settings;

--- a/src/MapLayer/MetaModelsLayerLabelRenderer.php
+++ b/src/MapLayer/MetaModelsLayerLabelRenderer.php
@@ -18,7 +18,7 @@ use Contao\Backend;
 use Contao\CoreBundle\Framework\Adapter;
 use MetaModels\Factory as MetaModelsFactory;
 use Netzmacht\Contao\Leaflet\Backend\Renderer\Label\Layer\AbstractLabelRenderer;
-use Symfony\Component\Translation\TranslatorInterface as Translator;
+use Symfony\Contracts\Translation\TranslatorInterface as Translator;
 
 /**
  * Class MetaModelsLayerLabelRenderer

--- a/src/Renderer/MarkerRenderer.php
+++ b/src/Renderer/MarkerRenderer.php
@@ -160,7 +160,8 @@ class MarkerRenderer extends AbstractRenderer
             $lat = $item->get($latAttribute->getColName());
             $lng = $item->get($lngAttribute->getColName());
 
-            if (!strlen($lat) || !strlen($lng)) {
+
+            if ($lat == '' || $lat === null || $lat == '' || $lat === null) {
                 return null;
             }
 

--- a/src/Renderer/MarkerRenderer.php
+++ b/src/Renderer/MarkerRenderer.php
@@ -161,7 +161,7 @@ class MarkerRenderer extends AbstractRenderer
             $lng = $item->get($lngAttribute->getColName());
 
 
-            if ($lat == '' || $lat === null || $lat == '' || $lat === null) {
+            if ($lat === '' || $lat === null || $lat === '' || $lat === null) {
                 return null;
             }
 

--- a/src/Resources/contao/dca/tl_leaflet_mm_renderer.php
+++ b/src/Resources/contao/dca/tl_leaflet_mm_renderer.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-metamodels
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2015-2019 netzmacht David Molineus
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2015-2022 netzmacht David Molineus
  * @license    LGPL 3.0-or-later https://github.com/netzmacht/contao-leaflet-metamodels/blob/master/LICENSE
  * @filesource
  */
@@ -66,7 +67,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_mm_renderer'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_mm_renderer']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [


### PR DESCRIPTION
Hi @dmolineus 

this PR will add support for metamodels 2.3.

We had to remove the support of symfony/* ^3.4 and ^4.0 'cause the contao-community-alliance/translator requires "symfony/translation" only in version "^5.4" and there was an API break in the TranslatorInterface.

What do you think, is this okay for you or do you have any concerns? 