### PR TITLE
Fix BC-Break from MM core 2.3

### DIFF
--- a/src/Resources/config/listeners.xml
+++ b/src/Resources/config/listeners.xml
@@ -22,6 +22,7 @@
             <argument type="service" id="database_connection"/>
             <argument type="service" id="metamodels.template_list"/>
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="translator"/>
         </service>
 
         <service id="Netzmacht\Contao\Leaflet\MetaModels\EventListener\Dca\RendererDcaListener" public="true">


### PR DESCRIPTION
Sorry! We have a BC-Break in MM core 2.3
https://github.com/MetaModels/core/blob/f8190de7be9994bdad91eea8cd3ef838a5b8f94e/src/CoreBundle/Contao/Hooks/AbstractContentElementAndModuleCallback.php#L133

I hope, you can add the parameter...